### PR TITLE
Openenclave-public

### DIFF
--- a/docs/Java_API.md
+++ b/docs/Java_API.md
@@ -52,5 +52,5 @@ The execution providers are preferred in the order they were enabled.
 
 ## API Reference
 
-The Javadoc is available [here](https://microsoft.github.io/onnxruntime/java/index.html).
+The Javadoc is available [here](https://microsoft.github.io/onnxruntime/docs/api/java/index.html).
 


### PR DESCRIPTION
Bump ajv from 6.12.2 to 6.12.6 in /nodejs

**Description**: Describe your changes.
Fixed a link to the JAVA docs - current link was broken -- added `docs/api` to the link.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

Fixed the link in the md file in the documentation as it was going to a 404 page.