### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/cgmanifests/cgmanifest.json
+++ b/cgmanifests/cgmanifest.json
@@ -1,311 +1,312 @@
 {
-   "Registrations": [
-      {
-         "component": {
-            "type": "git",
-            "git": {
-               "commitHash": "58123b93bd7f12d17ac0c46379a0f2c0255d9213",
-               "repositoryUrl": "https://github.com/martinmoene/gsl-lite.git"
-            }
-         }
-      },
-      {
-         "component": {
-            "type": "git",
-            "git": {
-               "commitHash": "638d7d2407de27f98f542f61a37a33c90a2e75a9",
-               "repositoryUrl": "https://github.com/microsoft/onnxruntime-tvm.git"
-            }
-         }
-      },
-      {
-         "component": {
-            "type": "git",
-            "git": {
-               "commitHash": "e4a4c02764d37c9c3db0d64c4996651a3ef9513c",
-               "repositoryUrl": "https://github.com/dmlc/HalideIR.git"
-            }
-         }
-      },
-      {
-         "component": {
-            "type": "git",
-            "git": {
-               "commitHash": "bee4d1dd8dc1ee4a1fd8fa6a96476c2f8b7492a3",
-               "repositoryUrl": "https://github.com/dmlc/dlpack.git"
-            }
-         }
-      },
-      {
-         "component": {
-            "type": "git",
-            "git": {
-               "commitHash": "4d49691f1a9d944c3b0aa5e63f1db3cad1f941f8",
-               "repositoryUrl": "https://github.com/dmlc/dmlc-core.git"
-            }
-         }
-      },
-      {
-         "component": {
-            "type": "git",
-            "git": {
-               "commitHash": "e02b83cc5e3c4d30f93dba945162e3aa58d962d6",
-               "repositoryUrl": "https://github.com/jemalloc/jemalloc.git"
-            }
-         }
-      },
-      {
-         "component": {
-            "type": "git",
-            "git": {
-               "commitHash": "7de7e5d02bf687f971e7668963649728356e0c20",
-               "repositoryUrl": "https://github.com/intel/mkl-dnn.git"
-            }
-         }
-      },
-      {
-         "component": {
-            "type": "git",
-            "git": {
-               "commitHash": "d860915b0198ddb96f93e9e97a789af156544dc6",
-               "repositoryUrl": "https://github.com/tensorflow/tensorflow.git"
-            }
-         }
-      },
-      {
-         "component": {
-            "type": "git",
-            "git": {
-               "commitHash": "eddf9023206dc40974c26f589ee2ad63a4227a1e",
-               "repositoryUrl": "https://github.com/glennrp/libpng.git"
-            }
-         }
-      },
-      {
-         "component": {
-            "type": "git",
-            "git": {
-               "commitHash": "217f52fb121ef92491e5d5f71394b07ce4ead1d0",
-               "repositoryUrl": "https://github.com/KjellKod/g3log.git"
-            }
-         }
-      },
-      {
-         "component": {
-            "type": "git",
-            "git": {
-               "commitHash": "50893291621658f355bc5b4d450a8d06a563053d",
-               "repositoryUrl": "https://github.com/madler/zlib.git"
-            }
-         }
-      },
-      {
-         "component": {
-            "type": "git",
-            "git": {
-               "commitHash": "d264a2603493fecda607c1d1cda87fedba77d36b",
-               "repositoryUrl": "https://github.com/Microsoft/CNTK.git"
-            }
-         }
-      },
-      {
-         "component": {
-            "type": "git",
-            "git": {
-               "commitHash": "971e2e89d08deeae0139d3011d15646fdac13c92",
-               "repositoryUrl": "https://github.com/numpy/numpy.git"
-            }
-         }
-      },
-      {
-         "component": {
-            "type": "git",
-            "git": {
-               "commitHash": "90537289a04ef5d572496240e2ac3a881be518d2",
-               "repositoryUrl": "https://github.com/pytorch/pytorch.git"
-            }
-         }
-      },
-      {
-         "component": {
-            "type": "git",
-            "git": {
-               "commitHash": "7389dbac82d362f296dc2746f10e43ffa1615660",
-               "repositoryUrl": "https://github.com/scikit-learn/scikit-learn.git"
-            }
-         }
-      },
-      {
-         "component": {
-            "type": "git",
-            "git": {
-               "commitHash": "eeebdab16155d34ff8f5f42137da7df4d1c7eab0",
-               "repositoryUrl": "https://github.com/BVLC/caffe.git"
-            }
-         }
-      },
-      {
-         "component": {
-            "Type": "other",
-            "Other": {
-               "Name": "LLVM",
-               "Version": "9.0.0",
-               "DownloadUrl": "https://releases.llvm.org/9.0.0/llvm-9.0.0.src.tar.xz"
-            }
-         }
-      },
-      {
-         "component": {
-            "Type": "other",
-            "Other": {
-               "Name": "FreeBSD GetOpt",
-               "Version": "12.0.0",
-               "DownloadUrl": "https://svnweb.freebsd.org/base/release/12.0.0/lib/libc/stdlib/getopt.c?revision=341707&view=co"
-            }
-         }
-      },
-      {
-         "component": {
-            "type": "git",
-            "git": {
-               "commitHash": "950fbf183274ab7d2092f99bab6c809ae87c7054",
-               "repositoryUrl": "https://github.com/NervanaSystems/ngraph.git"
-            }
-         }
-      },
-      {
-         "component": {
-            "type": "git",
-            "git": {
-               "commitHash": "647d4c3f4d47d9cf63fb90ec175c414a005adea7",
-               "repositoryUrl": "https://github.com/JDAI-CV/DNNLibrary.git"
-            }
-         }
-      },
-      {
-         "component": {
-            "Type": "other",
-            "Other": {
-               "Name": "Boost",
-               "Version": "1.69.0",
-               "DownloadUrl": "http://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2"
-            }
-         }
-      },
-      {
-         "component": {
-            "git": {
-               "commitHash": "02a2a458ac15912d7d87cc1171e811b0c5219ece",
-               "repositoryUrl": "https://github.com/grpc/grpc"
-            },
-            "type": "git"
-         }
-      },
-      {
-         "component": {
-            "git": {
-               "commitHash": "b29b21a81b32ec273f118f589f46d56ad3332420",
-               "repositoryUrl": "https://github.com/google/boringssl.git"
-            },
-            "type": "git"
-         }
-      },
-      {
-         "component": {
-            "git": {
-               "commitHash": "3be1924221e1326df520f8498d704a5c4c8d0cce",
-               "repositoryUrl": "https://github.com/c-ares/c-ares.git"
-            },
-            "type": "git"
-         }
-      },
-      {
-         "component": {
-            "git": {
-               "commitHash": "6599cac0965be8e5a835ab7a5684bbef033d5ad0",
-               "repositoryUrl": "https://github.com/llvm-mirror/libcxx.git"
-            },
-            "type": "git"
-         }
-      },
-      {
-         "component": {
-            "git": {
-               "commitHash": "9245d481eb3e890f708ff2d7dadf2a10c04748ba",
-               "repositoryUrl": "https://github.com/llvm-mirror/libcxxabi.git"
-            },
-            "type": "git"
-         }
-      },
-      {
-         "component": {
-            "git": {
-               "commitHash": "9ce4a77f61c134bbed28bfd5be5cd7dc0e80f5e3",
-               "repositoryUrl": "https://github.com/google/upb.git"
-            },
-            "type": "git"
-         }
-      },
-      {
-         "component": {
-            "type": "other",
-            "Other": {
-               "Name": "Go",
-               "Version": "1.12.6",
-               "DownloadUrl": "https://dl.google.com/go/go1.12.6.linux-amd64.tar.gz"
-            }
-         }
-      },
-      {
-         "component": {
-            "git": {
-               "commitHash": "cc4bed2d74f7c8717e31f9579214ab52a9c9c610",
-               "repositoryUrl": "https://github.com/abseil/abseil-cpp"
-            },
-            "type": "git",
-            "comments": "used by onnxruntime server"
-         }
-      },
-      {
-         "component": {
-            "type": "git",
-            "git": {
-               "commitHash": "256be563447a315f2a7993ec669460ba475fa86a",
-               "repositoryUrl": "https://github.com/abseil/abseil-cpp"
-            },
-            "comments": "used by onnxruntime"
-         }
-      },
-      {
-         "component": {
-            "Type": "other",
-            "Other": {
-               "Name": "OpenMPI",
-               "Version": "4.0.0",
-               "DownloadUrl": "https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.0.tar.gz"
-            }
-         }
-      },
-      {
-         "component": {
-            "Type": "other",
-            "Other": {
-               "Name": "NCCL",
-               "Version": "2.4.8",
-               "DownloadUrl": "https://docs.nvidia.com/deeplearning/sdk/nccl-install-guide/index.html"
-            }
-         }
-      },
-      {
-         "component": {
-            "type": "git",
-            "git": {
-               "commitHash": "67afac65ce64fd4dce1494f43e565e8fe34bdffb",
-               "repositoryUrl": "https://android.googlesource.com/platform/frameworks/ml"
-            },
-            "comments": "used by onnxruntime"
-         }
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "58123b93bd7f12d17ac0c46379a0f2c0255d9213",
+          "repositoryUrl": "https://github.com/martinmoene/gsl-lite.git"
+        }
       }
-   ],
-   "Version": 1
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "638d7d2407de27f98f542f61a37a33c90a2e75a9",
+          "repositoryUrl": "https://github.com/microsoft/onnxruntime-tvm.git"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "e4a4c02764d37c9c3db0d64c4996651a3ef9513c",
+          "repositoryUrl": "https://github.com/dmlc/HalideIR.git"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "bee4d1dd8dc1ee4a1fd8fa6a96476c2f8b7492a3",
+          "repositoryUrl": "https://github.com/dmlc/dlpack.git"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "4d49691f1a9d944c3b0aa5e63f1db3cad1f941f8",
+          "repositoryUrl": "https://github.com/dmlc/dmlc-core.git"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "e02b83cc5e3c4d30f93dba945162e3aa58d962d6",
+          "repositoryUrl": "https://github.com/jemalloc/jemalloc.git"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "7de7e5d02bf687f971e7668963649728356e0c20",
+          "repositoryUrl": "https://github.com/intel/mkl-dnn.git"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "d860915b0198ddb96f93e9e97a789af156544dc6",
+          "repositoryUrl": "https://github.com/tensorflow/tensorflow.git"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "eddf9023206dc40974c26f589ee2ad63a4227a1e",
+          "repositoryUrl": "https://github.com/glennrp/libpng.git"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "217f52fb121ef92491e5d5f71394b07ce4ead1d0",
+          "repositoryUrl": "https://github.com/KjellKod/g3log.git"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "50893291621658f355bc5b4d450a8d06a563053d",
+          "repositoryUrl": "https://github.com/madler/zlib.git"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "d264a2603493fecda607c1d1cda87fedba77d36b",
+          "repositoryUrl": "https://github.com/Microsoft/CNTK.git"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "971e2e89d08deeae0139d3011d15646fdac13c92",
+          "repositoryUrl": "https://github.com/numpy/numpy.git"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "90537289a04ef5d572496240e2ac3a881be518d2",
+          "repositoryUrl": "https://github.com/pytorch/pytorch.git"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "7389dbac82d362f296dc2746f10e43ffa1615660",
+          "repositoryUrl": "https://github.com/scikit-learn/scikit-learn.git"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "eeebdab16155d34ff8f5f42137da7df4d1c7eab0",
+          "repositoryUrl": "https://github.com/BVLC/caffe.git"
+        }
+      }
+    },
+    {
+      "component": {
+        "Type": "other",
+        "Other": {
+          "Name": "LLVM",
+          "Version": "9.0.0",
+          "DownloadUrl": "https://releases.llvm.org/9.0.0/llvm-9.0.0.src.tar.xz"
+        }
+      }
+    },
+    {
+      "component": {
+        "Type": "other",
+        "Other": {
+          "Name": "FreeBSD GetOpt",
+          "Version": "12.0.0",
+          "DownloadUrl": "https://svnweb.freebsd.org/base/release/12.0.0/lib/libc/stdlib/getopt.c?revision=341707&view=co"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "950fbf183274ab7d2092f99bab6c809ae87c7054",
+          "repositoryUrl": "https://github.com/NervanaSystems/ngraph.git"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "647d4c3f4d47d9cf63fb90ec175c414a005adea7",
+          "repositoryUrl": "https://github.com/JDAI-CV/DNNLibrary.git"
+        }
+      }
+    },
+    {
+      "component": {
+        "Type": "other",
+        "Other": {
+          "Name": "Boost",
+          "Version": "1.69.0",
+          "DownloadUrl": "http://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2"
+        }
+      }
+    },
+    {
+      "component": {
+        "git": {
+          "commitHash": "02a2a458ac15912d7d87cc1171e811b0c5219ece",
+          "repositoryUrl": "https://github.com/grpc/grpc"
+        },
+        "type": "git"
+      }
+    },
+    {
+      "component": {
+        "git": {
+          "commitHash": "b29b21a81b32ec273f118f589f46d56ad3332420",
+          "repositoryUrl": "https://github.com/google/boringssl.git"
+        },
+        "type": "git"
+      }
+    },
+    {
+      "component": {
+        "git": {
+          "commitHash": "3be1924221e1326df520f8498d704a5c4c8d0cce",
+          "repositoryUrl": "https://github.com/c-ares/c-ares.git"
+        },
+        "type": "git"
+      }
+    },
+    {
+      "component": {
+        "git": {
+          "commitHash": "6599cac0965be8e5a835ab7a5684bbef033d5ad0",
+          "repositoryUrl": "https://github.com/llvm-mirror/libcxx.git"
+        },
+        "type": "git"
+      }
+    },
+    {
+      "component": {
+        "git": {
+          "commitHash": "9245d481eb3e890f708ff2d7dadf2a10c04748ba",
+          "repositoryUrl": "https://github.com/llvm-mirror/libcxxabi.git"
+        },
+        "type": "git"
+      }
+    },
+    {
+      "component": {
+        "git": {
+          "commitHash": "9ce4a77f61c134bbed28bfd5be5cd7dc0e80f5e3",
+          "repositoryUrl": "https://github.com/google/upb.git"
+        },
+        "type": "git"
+      }
+    },
+    {
+      "component": {
+        "type": "other",
+        "Other": {
+          "Name": "Go",
+          "Version": "1.12.6",
+          "DownloadUrl": "https://dl.google.com/go/go1.12.6.linux-amd64.tar.gz"
+        }
+      }
+    },
+    {
+      "component": {
+        "git": {
+          "commitHash": "cc4bed2d74f7c8717e31f9579214ab52a9c9c610",
+          "repositoryUrl": "https://github.com/abseil/abseil-cpp"
+        },
+        "type": "git",
+        "comments": "used by onnxruntime server"
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "256be563447a315f2a7993ec669460ba475fa86a",
+          "repositoryUrl": "https://github.com/abseil/abseil-cpp"
+        },
+        "comments": "used by onnxruntime"
+      }
+    },
+    {
+      "component": {
+        "Type": "other",
+        "Other": {
+          "Name": "OpenMPI",
+          "Version": "4.0.0",
+          "DownloadUrl": "https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.0.tar.gz"
+        }
+      }
+    },
+    {
+      "component": {
+        "Type": "other",
+        "Other": {
+          "Name": "NCCL",
+          "Version": "2.4.8",
+          "DownloadUrl": "https://docs.nvidia.com/deeplearning/sdk/nccl-install-guide/index.html"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "67afac65ce64fd4dce1494f43e565e8fe34bdffb",
+          "repositoryUrl": "https://android.googlesource.com/platform/frameworks/ml"
+        },
+        "comments": "used by onnxruntime"
+      }
+    }
+  ],
+  "Version": 1
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.